### PR TITLE
fix: add type to imageKey to prevent cross-type image override

### DIFF
--- a/src/BeautySelectorAddon.ts
+++ b/src/BeautySelectorAddon.ts
@@ -71,6 +71,7 @@ export class BeautySelectorAddonImgGetterIndexedDB implements IModImgGetter {
     constructor(
         public modName: string,
         public modHashString: string,
+        public type: string,
         public imgPath: string,
         public imageStore: ModImageStore,
         public logger: LogWrapper,
@@ -91,7 +92,7 @@ export class BeautySelectorAddonImgGetterIndexedDB implements IModImgGetter {
         }
 
         try {
-            const imageData = await this.imageStore.getImage(this.modName, this.modHashString, this.imgPath);
+            const imageData = await this.imageStore.getImage(this.modName, this.modHashString, this.type, this.imgPath);
             if (imageData) {
                 return imageData;
             } else {
@@ -372,7 +373,7 @@ export class BeautySelectorAddon implements AddonPluginHookPointEx, BeautySelect
                     imgList.set(imagePath, {
                         path: imagePath,
                         realPath: imagePath, // Not needed for IndexedDB version
-                        getter: new BeautySelectorAddonImgGetterIndexedDB(modName, modHash.toString(), imagePath, this.imageStore, this.logger),
+                        getter: new BeautySelectorAddonImgGetterIndexedDB(modName, modHash.toString(), type, imagePath, this.imageStore, this.logger),
                     });
                 }
             }
@@ -492,7 +493,7 @@ export class BeautySelectorAddon implements AddonPluginHookPointEx, BeautySelect
                             imgList.set(imagePath, {
                                 path: imagePath,
                                 realPath: imagePath, // Not needed for IndexedDB version
-                                getter: new BeautySelectorAddonImgGetterIndexedDB(modName, modHash.toString(), imagePath, this.imageStore, this.logger),
+                                getter: new BeautySelectorAddonImgGetterIndexedDB(modName, modHash.toString(), type, imagePath, this.imageStore, this.logger),
                             });
                         }
                     }
@@ -570,7 +571,7 @@ export class BeautySelectorAddon implements AddonPluginHookPointEx, BeautySelect
                             imgList.set(imagePath, {
                                 path: imagePath,
                                 realPath: imagePath, // Not needed for IndexedDB version
-                                getter: new BeautySelectorAddonImgGetterIndexedDB(modName, modHash.toString(), imagePath, this.imageStore, this.logger),
+                                getter: new BeautySelectorAddonImgGetterIndexedDB(modName, modHash.toString(), type, imagePath, this.imageStore, this.logger),
                             });
                         }
                     }

--- a/src/ModImageStore.ts
+++ b/src/ModImageStore.ts
@@ -338,7 +338,7 @@ export class ModImageStore {
 
         // Use direct put() method which internally creates and commits short transactions
         const storeImage = async (imagePath: string, realPath: string, imageData: string) => {
-            const imageKey = `${modName}_${modHashString}_${imagePath}`;
+            const imageKey = `${modName}_${modHashString}_${type}_${imagePath}`;
             const imageRecord = {
                 modName,
                 modHashString,
@@ -375,7 +375,7 @@ export class ModImageStore {
     /**
      * Get image data by path
      */
-    async getImage(modName: string, modHashString: string, imagePath: string): Promise<string | undefined> {
+    async getImage(modName: string, modHashString: string, type: string, imagePath: string): Promise<string | undefined> {
         try {
             await this.iniImageStore();
         } catch (e) {
@@ -383,7 +383,7 @@ export class ModImageStore {
             throw e;
         }
 
-        const imageKey = `${modName}_${modHashString}_${imagePath}`;
+        const imageKey = `${modName}_${modHashString}_${type}_${imagePath}`;
         const imageRecord = await this.dbRef!.get('imageStore', imageKey);
         return imageRecord?.imageData;
     }


### PR DESCRIPTION
The imageKey in IndexedDB was constructed without the type identifier, causing images from different types within the same mod to overwrite each other. When multiple beauty packs within a mod share the same image filenames (e.g., different colored pepper spray variants), enabling/disabling individual packs via the ModLoader GUI had no effect because all types shared the same IndexedDB key.

Fix: Include 'type' in the imageKey format and add type parameter to getImage() and BeautySelectorAddonImgGetterIndexedDB constructor.

Fixes https://github.com/Lyoko-Jeremie/DoL_BeautySelectorAddonMod/issues/3